### PR TITLE
Updated maven project and fixes of minor issues & warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Maven output
+/target/
+
+# IntelliJ IDEA project files
+/.idea/
+*.iml
+*.ipr
+
+# Eclipse project files
+.project
+.classpath
+/.settings/
+
+# Versions Maven Plugin backups
+*.versionsBackup

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>mojo-parent</artifactId>
     <groupId>org.codehaus.mojo</groupId>
-    <version>30</version>
+    <version>50</version>
   </parent>
   <artifactId>jboss-packaging-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
@@ -51,9 +51,9 @@
   </issueManagement>
   
   <scm>
-    <connection>scm:svn:http://svn.codehaus.org/mojo/trunk/mojo/jboss-packaging-maven-plugin</connection>
-    <developerConnection>scm:svn:https://svn.codehaus.org/mojo/trunk/mojo/jboss-packaging-maven-plugin</developerConnection>
-    <url>http://fisheye.codehaus.org/browse/mojo/trunk/mojo/jboss-packaging-maven-plugin</url>
+    <connection>scm:git:https://github.com/jboss-packaging-maven-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/jboss-packaging-maven-plugin.git</developerConnection>
+    <url>https://github.com/jboss-packaging-maven-plugin</url>
   </scm>
   
   <dependencies>
@@ -65,11 +65,6 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>${mavenVersion}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
       <version>${mavenVersion}</version>
     </dependency>
     <dependency>
@@ -110,9 +105,28 @@
   </dependencies>
   
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <mavenVersion>2.0.6</mavenVersion>
+    <mavenVersion>3.0</mavenVersion>
+    <invoker.maven.compiler.source>${mojo.java.target}</invoker.maven.compiler.source>
+    <invoker.maven.compiler.target>${mojo.java.target}</invoker.maven.compiler.target>
   </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-invoker-plugin</artifactId>
+          <version>3.2.1</version>
+          <configuration>
+            <properties>
+              <maven.compiler.source>${invoker.maven.compiler.source}</maven.compiler.source>
+              <maven.compiler.target>${invoker.maven.compiler.target}</maven.compiler.target>
+            </properties>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 
   <reporting>
     <plugins>
@@ -171,7 +185,7 @@
                   <showErrors>true</showErrors>
                   <goals>
                     <goal>clean</goal>
-                    <goal>process-classes</goal>
+                    <goal>package</goal>
                   </goals>
                 </configuration>
               </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
   </licenses>
 
   <issueManagement>
-    <system>JIRA</system>
-    <url>http://jira.codehaus.org/browse/MJBOSSPACK</url>
+    <system>GitHub</system>
+    <url>https://github.com/mojohaus/jboss-packaging-maven-plugin/issues</url>
   </issueManagement>
   
   <scm>
@@ -108,6 +108,7 @@
     <mavenVersion>3.0</mavenVersion>
     <invoker.maven.compiler.source>${mojo.java.target}</invoker.maven.compiler.source>
     <invoker.maven.compiler.target>${mojo.java.target}</invoker.maven.compiler.target>
+    <maven-changes-plugin.version>2.12.1</maven-changes-plugin.version>
   </properties>
 
   <build>
@@ -128,36 +129,9 @@
     </pluginManagement>
   </build>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-changes-plugin</artifactId>
-        <configuration>
-          <onlyCurrentVersion>true</onlyCurrentVersion>
-          <columnNames>Type,Key,Summary,Status,Resolution,Assignee</columnNames>
-          <sortColumnNames>Type,Key</sortColumnNames>
-        </configuration>
-        <reportSets>
-          <reportSet>
-            <reports>
-              <report>jira-report</report>
-            </reports>
-          </reportSet>
-        </reportSets>
-      </plugin>
-    </plugins>
-  </reporting>
-
   <profiles>
     <profile>
       <id>run-its</id>
-      <activation>
-        <property>
-          <name>maven.test.skip</name>
-          <value>!true</value>
-        </property>
-      </activation>
       <build>
         <plugins>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-changes-plugin</artifactId>
-        <version>2.3</version>
         <configuration>
           <onlyCurrentVersion>true</onlyCurrentVersion>
           <columnNames>Type,Key,Summary,Status,Resolution,Assignee</columnNames>

--- a/src/it/jdk15-tests/MJBOSSPACK-1-ejb-client/ejb-module/pom.xml
+++ b/src/it/jdk15-tests/MJBOSSPACK-1-ejb-client/ejb-module/pom.xml
@@ -26,14 +26,6 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-ejb-plugin</artifactId>
         <configuration>
           <ejbVersion>3.0</ejbVersion>

--- a/src/main/java/org/codehaus/mojo/jboss/packaging/AbstractPackagingMojo.java
+++ b/src/main/java/org/codehaus/mojo/jboss/packaging/AbstractPackagingMojo.java
@@ -112,7 +112,7 @@ public abstract class AbstractPackagingMojo
     /**
      * All artifacts are excluded.
      * 
-     * @parameter expression="${excludeAll}" default-value="false"
+     * @parameter property="excludeAll" default-value="false"
      */
     private boolean excludeAll;
 
@@ -186,7 +186,7 @@ public abstract class AbstractPackagingMojo
      * Whether to generate only the exploded archive format. By default both an exploded directory and a zipped file
      * will be created. If set to "true" only the exploded directory will be created.
      * 
-     * @parameter default-value="false" expression="${explodedOnly}"
+     * @parameter default-value="false" property="explodedOnly"
      * @since 2.0
      */
     private boolean explodedOnly;
@@ -258,7 +258,6 @@ public abstract class AbstractPackagingMojo
      * Build the package in an exploded format.
      * 
      * @throws MojoExecutionException if an error occurred
-     * @throws MojoFailureException if an error occurred
      */
     public void buildExplodedPackaging()
         throws MojoExecutionException
@@ -271,7 +270,6 @@ public abstract class AbstractPackagingMojo
      * 
      * @param excludes File patterns to exclude from the packaging.
      * @throws MojoExecutionException if an error occurred
-     * @throws MojoFailureException if an error occurred
      */
     public void buildExplodedPackaging( Set excludes )
         throws MojoExecutionException
@@ -399,7 +397,7 @@ public abstract class AbstractPackagingMojo
         {
             String[] files = libDirectory.list();
 
-            if ( files.length == 0 )
+            if ( files != null && files.length == 0 )
             {
                 libDirectory.delete();
             }
@@ -411,8 +409,6 @@ public abstract class AbstractPackagingMojo
      * 
      * @param excludes The exclude list.
      * @throws MojoExecutionException For plugin failures.
-     * @throws MojoFailureException For unexpected plugin failures.
-     * @throws IOException For exceptions during IO operations.
      */
     protected void buildSpecificPackaging( final Set excludes )
         throws MojoExecutionException

--- a/src/main/java/org/codehaus/mojo/jboss/packaging/AopMojo.java
+++ b/src/main/java/org/codehaus/mojo/jboss/packaging/AopMojo.java
@@ -43,7 +43,7 @@ public class AopMojo
      * then it will automatically be included. Otherwise this parameter must be set.
      * 
      * @parameter default-value="${project.build.outputDirectory}/META-INF/jboss-aop.xml"
-     *            expression="${deploymentDescriptorFile}"
+     *            property="deploymentDescriptorFile"
      */
     private File deploymentDescriptorFile;
 

--- a/src/main/java/org/codehaus/mojo/jboss/packaging/ESBExplodedMojo.java
+++ b/src/main/java/org/codehaus/mojo/jboss/packaging/ESBExplodedMojo.java
@@ -37,7 +37,6 @@ public class ESBExplodedMojo
      * Execute the mojo in the current project.
      * 
      * @throws MojoExecutionException For plugin failures.
-     * @throws MojoFailureException For unexpected plugin failures.
      */
     public void execute()
         throws MojoExecutionException

--- a/src/main/java/org/codehaus/mojo/jboss/packaging/ESBMojo.java
+++ b/src/main/java/org/codehaus/mojo/jboss/packaging/ESBMojo.java
@@ -56,7 +56,7 @@ public class ESBMojo
     /**
      * Override the deployment xml file
      * 
-     * @parameter expression="${maven.esb.deployment.xml}"
+     * @parameter property="maven.esb.deployment.xml"
      */
     private File deploymentXml;
 
@@ -65,7 +65,7 @@ public class ESBMojo
      * src/main/resources/META-INF then it will automatically be included. Otherwise this parameter must be set.
      * 
      * @parameter default-value="${project.build.outputDirectory}/META-INF/jboss-esb.xml"
-     *            expression="${deploymentDescriptorFile}"
+     *            property="deploymentDescriptorFile"
      */
     private File deploymentDescriptorFile;
 
@@ -74,8 +74,6 @@ public class ESBMojo
      * 
      * @param excludes The exclude list.
      * @throws MojoExecutionException For plugin failures.
-     * @throws MojoFailureException For unexpected plugin failures.
-     * @throws IOException For exceptions during IO operations.
      */
     protected void buildSpecificPackaging( final Set excludes )
         throws MojoExecutionException

--- a/src/main/java/org/codehaus/mojo/jboss/packaging/HarExplodedMojo.java
+++ b/src/main/java/org/codehaus/mojo/jboss/packaging/HarExplodedMojo.java
@@ -37,7 +37,6 @@ public class HarExplodedMojo
      * Main plugin execution path.
      * 
      * @throws MojoExecutionException if an error occurred
-     * @throws MojoFailureException if an error occurred
      */
     public void execute()
         throws MojoExecutionException

--- a/src/main/java/org/codehaus/mojo/jboss/packaging/HarMojo.java
+++ b/src/main/java/org/codehaus/mojo/jboss/packaging/HarMojo.java
@@ -42,7 +42,7 @@ public class HarMojo
      * The name of the hibernate deployment descriptor file. If left blank, the goal will automatically search for
      * "jboss-service.xml", "hibernate-service.xml", and "*-hibernate.xml" in that order.
      * 
-     * @parameter expression="${deploymentDescriptorFile}"
+     * @parameter property="deploymentDescriptorFile"
      */
     private File deploymentDescriptorFile;
 
@@ -91,7 +91,7 @@ public class HarMojo
 
         // Look for "*-hibernate.xml" in META-INF
         String[] files = metaInf.list();
-        for ( int i = 0; i < files.length; ++i )
+        for ( int i = 0; files != null && i < files.length; ++i )
         {
             if ( files[i].endsWith( "-hibernate.xml" ) )
             {

--- a/src/main/java/org/codehaus/mojo/jboss/packaging/ParMojo.java
+++ b/src/main/java/org/codehaus/mojo/jboss/packaging/ParMojo.java
@@ -77,12 +77,12 @@ public class ParMojo
     /**
      * The character encoding of the resource files.
      * 
-     * @parameter expression="${encoding}" default-value="${project.build.sourceEncoding}"
+     * @parameter property="encoding" default-value="${project.build.sourceEncoding}"
      */
     private String encoding;
 
     /**
-     * @parameter expression="${session}"
+     * @parameter property="session"
      * @readonly
      * @required
      */
@@ -101,7 +101,7 @@ public class ParMojo
      * src/main/resources then it will automatically be included. Otherwise this parameter must be set.
      * 
      * @parameter default-value="${project.build.directory}/${project.build.finalName}/processdefinition.xml"
-     *            expression="${deploymentDescriptorFile}"
+     *            property="deploymentDescriptorFile"
      */
     private File deploymentDescriptorFile;
 
@@ -207,7 +207,7 @@ public class ParMojo
     }
 
     /**
-     * Overrides the default implementation to explode the depdencies into the classes directory.
+     * Overrides the default implementation to explode the dependencies into the classes directory.
      */
     protected void packageLib( Artifact artifact, String name )
         throws Exception

--- a/src/main/java/org/codehaus/mojo/jboss/packaging/SarExplodedMojo.java
+++ b/src/main/java/org/codehaus/mojo/jboss/packaging/SarExplodedMojo.java
@@ -37,7 +37,6 @@ public class SarExplodedMojo
      * Main plugin execution path.
      * 
      * @throws MojoExecutionException if an error occurred
-     * @throws MojoFailureException if an error occurred
      */
     public void execute()
         throws MojoExecutionException

--- a/src/main/java/org/codehaus/mojo/jboss/packaging/SarInPlaceExplodedMojo.java
+++ b/src/main/java/org/codehaus/mojo/jboss/packaging/SarInPlaceExplodedMojo.java
@@ -37,7 +37,6 @@ public class SarInPlaceExplodedMojo
      * Main plugin execution path.
      * 
      * @throws MojoExecutionException if an error occurred
-     * @throws MojoFailureException if an error occurred
      */
     public void execute()
         throws MojoExecutionException

--- a/src/main/java/org/codehaus/mojo/jboss/packaging/SarMojo.java
+++ b/src/main/java/org/codehaus/mojo/jboss/packaging/SarMojo.java
@@ -43,7 +43,7 @@ public class SarMojo
      * src/main/resources/META-INF then it will automatically be included. Otherwise this parameter must be set.
      * 
      * @parameter default-value="${project.build.outputDirectory}/META-INF/jboss-service.xml"
-     *            expression="${deploymentDescriptorFile}"
+     *            property="deploymentDescriptorFile"
      */
     private File deploymentDescriptorFile;
 

--- a/src/main/java/org/codehaus/mojo/jboss/packaging/SpringMojo.java
+++ b/src/main/java/org/codehaus/mojo/jboss/packaging/SpringMojo.java
@@ -39,7 +39,7 @@ public class SpringMojo
      * be set.
      * 
      * @parameter default-value="${project.build.outputDirectory}/META-INF/jboss-spring.xml"
-     *            expression="${deploymentDescriptorFile}"
+     *            property="deploymentDescriptorFile"
      */
     private File deploymentDescriptorFile;
 

--- a/src/site/apt/examples/example-assembly.apt.vm
+++ b/src/site/apt/examples/example-assembly.apt.vm
@@ -3,7 +3,7 @@
  ------
  Paul Gier <pgier at apache.org>
  ------
- August 4, 2009
+ 2009-08-04
  ------
 
 Maven Assembly Plugin Example

--- a/src/site/apt/examples/example-basic.apt.vm
+++ b/src/site/apt/examples/example-basic.apt.vm
@@ -3,7 +3,7 @@
  ------
  Paul Gier <pgier at apache.org>
  ------
- April 11 2008
+ 2008-04-11
  ------
 
 Basic Examples

--- a/src/site/apt/examples/example-dependency.apt.vm
+++ b/src/site/apt/examples/example-dependency.apt.vm
@@ -3,7 +3,7 @@
  ------
  Paul Gier <pgier at apache.org>
  ------
- November 13, 2009
+ 2009-11-13
  ------
 
 Dependency Examples


### PR DESCRIPTION
* Updated maven project to support latest JDK 8 and 11 by default
* Fixed warnings 'The syntax @parameter expression="${property}" is deprecated, please use @parameter property="property"'.
* Git ignored entries configured
